### PR TITLE
Adding a little note about nested groups

### DIFF
--- a/routing.md
+++ b/routing.md
@@ -93,6 +93,8 @@ Sometimes you may need to apply middleware to a group of routes. Instead of spec
 
 Shared attributes are specified in an array format as the first parameter to the `$app->group()` method.
 
+> **Note:** Unlike Laravel, nested groups will not work.
+
 <a name="route-group-middleware"></a>
 ### Middleware
 


### PR DESCRIPTION
As a Laravel user that came to Lumen, I kind of expected groups to work in the same way. I'm assuming that as an optimisation, the group stack was removed. It'd be nice to highlight this so that people (like myself) don't have to wade through the internals to find that it's a feature and not a bug. ;-)